### PR TITLE
added a new data type of structured_cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ if the data is defined at cells or elements, you can use
 
 if you've already setup system path to include the folder containing the ParaView binary, you can invoke ParaView directly by 
 
-    vtkwrite('execute', 'structured_cells', 'mri', D)
+    vtkwrite('execute', 'structured_points', 'mri', D)
 
 In this case, a file named 'matlab_export.vtk' is saved and passed on to ParaView.
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ The usage of vector and scalar field input is the same as built-in quiver3 and s
 In Paraview, press 'ctrl+o' to open file. Then on properties page immediately below pipeline browser, click 'Apply'. For line and polygon data, you should already see the correct representation of data. For 3D vector field, you have to further click on 'glyph' in the common toolbar, then choose the glyph object in the pipeline browser and click 'Apply'.
 
 See file for more details on usage.
+
+Contributors: Joe Yeh, James Avery, Alessandro Arduino, Suguang Dou.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Example 1 : export 3D array (typical of an image volume )
     D = squeeze(D);  
     vtkwrite('mri.vtk', 'structured_points', 'mri', D)  
 
+if the data is defined at cells or elements, you can use
+
+    vtkwrite('mri.vtk', 'structured_cells', 'mri', D)  
+
 if you've already setup system path to include the folder containing the ParaView binary, you can invoke ParaView directly by 
 
-    vtkwrite('execute', 'structured_points', 'mri', D)
+    vtkwrite('execute', 'structured_cells', 'mri', D)
 
 In this case, a file named 'matlab_export.vtk' is saved and passed on to ParaView.
 

--- a/demo.m
+++ b/demo.m
@@ -1,0 +1,7 @@
+% a short demo of vtk files and vtkwrite.m
+% author: Suguang Dou 
+% added on Feb 18, 2022
+% for 2D/3D data at structured points or nodes
+vtkwrite('ex1.vtk','structured_points','var1',rand(2,2)),type ex1.vtk
+% for 2D/3D data at structured cells or elements
+vtkwrite('ex2.vtk','structured_cells','var2',rand(2,2)),type ex2.vtk

--- a/vtkwrite.m
+++ b/vtkwrite.m
@@ -80,7 +80,47 @@ else
 end
 
 switch upper(dataType)
-    case 'STRUCTURED_POINTS'
+        case 'STRUCTURED_CELLS'
+        title = varargin{1};
+        m = varargin{2};
+        if any(strcmpi(varargin, 'spacing'))
+            sx = varargin{find(strcmpi(varargin, 'spacing'))+1};
+            sy = varargin{find(strcmpi(varargin, 'spacing'))+2};
+            sz = varargin{find(strcmpi(varargin, 'spacing'))+3};
+        else
+            sx = 1;
+            sy = 1;
+            sz = 1;
+        end
+        if any(strcmpi(varargin, 'origin'))
+            ox = varargin{find(strcmpi(varargin, 'origin'))+1};
+            oy = varargin{find(strcmpi(varargin, 'origin'))+2};
+            oz = varargin{find(strcmpi(varargin, 'origin'))+3};
+        else
+            ox = 0;
+            oy = 0;
+            oz = 0;
+        end
+        [nx, ny, nz] = size(m);
+        setdataformat(fid, binaryflag);
+        
+        fprintf(fid, 'DATASET STRUCTURED_POINTS\n');
+        fprintf(fid, 'DIMENSIONS %d %d %d\n', nx+1, ny+1, nz+1);
+        fprintf(fid, ['SPACING ', num2str(sx), ' ', num2str(sy), ' ',...
+            num2str(sz), '\n']);
+        fprintf(fid, ['ORIGIN ', num2str(ox), ' ', num2str(oy), ' ',...
+            num2str(oz), '\n']); 
+        fprintf(fid, 'CELL_DATA %d\n', nx*ny*nz);
+        fprintf(fid, ['SCALARS ', title, ' float\n']);
+        fprintf(fid,'LOOKUP_TABLE default\n');
+        if ~binaryflag 
+            spec = ['%0.', precision, 'f '];
+            fprintf(fid, spec, m(:)');
+        else
+            fwrite(fid, m(:)', 'float', 'b');
+        end
+        
+    case 'STRUCTURED_POINTS' 
         title = varargin{1};
         m = varargin{2};
         if any(strcmpi(varargin, 'spacing'))
@@ -111,7 +151,7 @@ switch upper(dataType)
         fprintf(fid, ['ORIGIN ', num2str(ox), ' ', num2str(oy), ' ',...
             num2str(oz), '\n']); 
         fprintf(fid, 'POINT_DATA %d\n', nx*ny*nz);
-        fprintf(fid, ['SCALARS ', title, ' float 1\n']);
+        fprintf(fid, ['SCALARS ', title, ' float\n']);
         fprintf(fid,'LOOKUP_TABLE default\n');
         if ~binaryflag 
             spec = ['%0.', precision, 'f '];
@@ -224,7 +264,7 @@ switch upper(dataType)
         end     
 end
 
-if ~strcmpi(dataType,'STRUCTURED_POINTS')
+if ~strcmpi(dataType,'STRUCTURED_POINTS') && ~strcmpi(dataType,'STRUCTURED_CELLS')
     % 5.This final part describe the dataset attributes and begins with the
     % keywords 'POINT_DATA' or 'CELL_DATA', followed by an integer number
     % specifying the number of points of cells. Other keyword/data combination


### PR DESCRIPTION
It is used to output the 2D/3D array whose data is defined for cells or elements. When the data is imported into ParaView, one can then convert cell data to point data. This gives a more accurate procedure than directly treating the 2D/3D array as structured points. This function may be realized by using structured_grids. However, the new data type of structured_cells provides a more convenient way than structured_grids.